### PR TITLE
Changed tab separator value used in upload config form

### DIFF
--- a/app/EasyMinerModule/presenters/DataPresenter.php
+++ b/app/EasyMinerModule/presenters/DataPresenter.php
@@ -374,7 +374,7 @@ class DataPresenter extends BasePresenter{
       ','=>'Comma (,)',
       ';'=>'Semicolon (;)',
       '|'=>'Vertical line (|)',
-      '\t'=>'Tab (\t)'
+      chr(9) =>'Tab (\t)'
     ])->setRequired();
 
     $form->addSelect('encoding','Encoding:',[


### PR DESCRIPTION
Using '\t' as value for select option caused error on file config upload page for tab separated dataset files. 